### PR TITLE
Refactor project structure with verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FileOrganizerLLM
 
-FileOrganizerLLM analyzes a folder tree and summarizes each directory using a local large language model. The script scans files, extracts a text snippet, and calls `ollama` to produce concise descriptions. The resulting summaries are stored in `folder_contexts.json`.
+FileOrganizerLLM analyzes a folder tree and summarizes each directory using a local large language model. The tool scans files, extracts a text snippet, and calls `ollama` to produce concise descriptions. The resulting summaries are stored in `folder_contexts.json`.
 
 ## Requirements
 
@@ -16,10 +16,10 @@ pip install -r requirements.txt
 
 ## Usage
 
-1. Run the script and specify the root directory and other options via command line or the `FO_ROOT_DIR`, `FO_N_SAMPLE_FILES`, and `FO_OLLAMA_MODEL` environment variables. For example:
+1. Run the tool and specify the root directory and other options via command line or the `FO_ROOT_DIR`, `FO_N_SAMPLE_FILES`, and `FO_OLLAMA_MODEL` environment variables. For example:
 
 ```bash
-python FileOrganizer.py --root /path/to/root --samples 10 --model llama3
+python -m file_organizer --root /path/to/root --samples 10 --model llama3 --verbose
 ```
 
 A `folder_contexts.json` file will be created in the root directory containing the generated summaries.

--- a/file_organizer/__init__.py
+++ b/file_organizer/__init__.py
@@ -1,0 +1,6 @@
+"""File Organizer LLM package."""
+
+__all__ = ["main"]
+__version__ = "0.1.0"
+
+from .organizer import main

--- a/file_organizer/__main__.py
+++ b/file_organizer/__main__.py
@@ -1,0 +1,4 @@
+from .organizer import main
+
+if __name__ == "__main__":
+    main()

--- a/file_organizer/organizer.py
+++ b/file_organizer/organizer.py
@@ -8,6 +8,7 @@ from docx import Document
 import openpyxl
 from pptx import Presentation
 import PyPDF2
+import logging
 
 # ------ CONFIG ------
 # Configuration can be supplied via command line or environment variables.
@@ -26,6 +27,8 @@ def parse_args():
                         help="Ollama model name")
     parser.add_argument("--resume", action="store_true",
                         help="Resume from existing folder_contexts.json")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Enable verbose output")
     return parser.parse_args()
 
 # --- File Extractors ---
@@ -133,9 +136,9 @@ def call_ollama(prompt, model, retries=1):
         except subprocess.CalledProcessError as e:
             if attempt >= retries:
                 err = e.stderr.decode("utf-8", errors="replace")
-                print(f"[ollama error] {err}")
+                logging.error("[ollama error] %s", err)
                 return ""
-            print("Ollama failed, retrying...")
+            logging.warning("Ollama failed, retrying...")
 
 def get_file_summary(filepath, ollama_model):
     content = extract_text_file(filepath)
@@ -176,6 +179,8 @@ def get_folders_in_bottom_up_order(tree, root_dir):
 
 def main():
     args = parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        format="%(message)s")
     if not args.root:
         raise SystemExit("--root must be specified (or FO_ROOT_DIR env variable)")
 
@@ -192,10 +197,10 @@ def main():
 
     for folder in process_order:
         if folder in folder_contexts:
-            print(f"Skipping: {folder}")
+            logging.info("Skipping: %s", folder)
             continue
 
-        print(f"\nProcessing: {folder}")
+        logging.info("\nProcessing: %s", folder)
         # --- File-based summaries
         sample_files = get_sample_files(folder, args.samples)
         sample_summaries = []
@@ -224,16 +229,17 @@ Subfolder context summaries:
 
 Please summarize the main purpose or topic of this folder in 2-3 sentences, taking into account both its own files and the main themes of its immediate subfolders (if any). If you see outliers, ignore them. Only output the summary text.
 """
-        print(f"  Calling Ollama ({args.model})...")
+        logging.info("  Calling Ollama (%s)...", args.model)
         folder_summary = call_ollama(prompt, model=args.model)
-        print(f"  => {folder_summary}")
+        logging.info("  => %s", folder_summary)
 
         folder_contexts[folder] = folder_summary
 
         with open(out_json, "w", encoding="utf-8") as f:
             json.dump(folder_contexts, f, ensure_ascii=False, indent=2)
+        logging.info("Saved summary for %s", folder)
 
-    print(f"\nSaved folder contexts to {out_json}")
+    logging.info("\nSaved folder contexts to %s", out_json)
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "file-organizer-llm"
+version = "0.1.0"
+description = "Summarize folders using a local large language model."
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "Apache-2.0"}
+authors = [{name = "FileOrganizerLLM"}]
+dependencies = [
+    "python-docx",
+    "openpyxl",
+    "python-pptx",
+    "PyPDF2",
+]
+
+[project.scripts]
+file-organizer = "file_organizer.organizer:main"


### PR DESCRIPTION
## Summary
- reorganize project into `file_organizer` package
- add `__main__` so module can be run with `python -m file_organizer`
- implement verbose logging with `--verbose` flag
- document new invocation method
- add packaging metadata in `pyproject.toml`

## Testing
- `python -m file_organizer --help` *(fails: ModuleNotFoundError due to missing dependencies)*
- `pip install -r requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68838a38f2d08322a5dbc01d4ffd0040