### PR TITLE
Use new LangChain HuggingFace import

### DIFF
--- a/file_organizer/organizer.py
+++ b/file_organizer/organizer.py
@@ -11,7 +11,7 @@ import PyPDF2
 import logging
 from typing import Dict, Optional
 
-from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 
 # Preload the embedding model once for efficiency using LangChain
 _EMBED_MODEL = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "PyPDF2",
     "langchain",
     "langchain-community",
+    "langchain-huggingface",
     "langchain-ollama",
     "openai",
     "sentence-transformers",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-pptx
 PyPDF2
 langchain
 langchain-community
+langchain-huggingface
 langchain-ollama
 openai
 sentence-transformers

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -5,12 +5,12 @@ import importlib
 from unittest.mock import MagicMock
 
 # Patch HuggingFaceEmbeddings before importing organizer to avoid network calls
-mock_embeddings = types.ModuleType("langchain_community.embeddings")
+mock_embeddings = types.ModuleType("langchain_huggingface")
 mock_embed_instance = MagicMock()
 mock_embed_instance.embed_query.return_value = [0.0]
 mock_embeddings.HuggingFaceEmbeddings = MagicMock(return_value=mock_embed_instance)
 
-sys.modules['langchain_community.embeddings'] = mock_embeddings
+sys.modules['langchain_huggingface'] = mock_embeddings
 
 organizer = importlib.import_module('file_organizer.organizer')
 organizer.get_llm = MagicMock(return_value=MagicMock())


### PR DESCRIPTION
## Summary
- switch organizer to import `HuggingFaceEmbeddings` from `langchain_huggingface`
- update test mocks for new import path
- list `langchain-huggingface` in requirements and `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e77b8e4c8322a0d770b33564045f