### PR TITLE
Update test mocks for langchain_huggingface

### DIFF
--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -5,12 +5,13 @@ import importlib
 from unittest.mock import MagicMock
 
 # Patch HuggingFaceEmbeddings before importing organizer to avoid network calls
-mock_embeddings = types.ModuleType("langchain_community.embeddings")
+mock_embeddings = types.ModuleType("langchain_huggingface")
 mock_embed_instance = MagicMock()
 mock_embed_instance.embed_query.return_value = [0.0]
 mock_embeddings.HuggingFaceEmbeddings = MagicMock(return_value=mock_embed_instance)
 
-sys.modules['langchain_community.embeddings'] = mock_embeddings
+sys.modules['langchain_huggingface'] = mock_embeddings
+sys.modules['langchain_huggingface.embeddings'] = mock_embeddings
 
 organizer = importlib.import_module('file_organizer.organizer')
 organizer.get_llm = MagicMock(return_value=MagicMock())


### PR DESCRIPTION
## Summary
- update mocks in `tests/test_organizer.py` to provide a fake `langchain_huggingface` module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e8161d24832289854eb0466a0908