### PR TITLE
Add file-mapper utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ python -m file_organizer --root /path/to/root --provider fireworks --model accou
 
 A `folder_contexts.json` file will be created in the root directory containing the generated summaries.
 
+### Mapping new files
+
+To map files from another folder to the most relevant destination within an existing organized tree, run:
+
+```bash
+python -m file_organizer.mapper --input /path/to/new/files --root /path/to/root
+```
+
+The command creates a `file_mappings.json` file inside the input folder listing the suggested destination for each file. Use `--apply` to automatically move the files based on that mapping.
+
 ## How it works
 
 The script selects a few representative files from each folder, extracts up to 2000 characters of text from each, and asks the local LLM for a one-sentence summary. It processes folders from the bottom up so that subfolder summaries contribute to the description of their parent directories. The final output provides a short overview of each folder's main topic or purpose.

--- a/file_organizer/llm_provider.py
+++ b/file_organizer/llm_provider.py
@@ -1,4 +1,5 @@
 """LLM provider utilities for FileOrganizerLLM."""
+
 from __future__ import annotations
 
 from typing import Optional

--- a/file_organizer/mapper.py
+++ b/file_organizer/mapper.py
@@ -1,0 +1,95 @@
+import os
+import json
+import argparse
+import shutil
+from typing import Dict
+
+from .organizer import get_embedding, extract_text_file
+
+
+def cosine_similarity(v1: list[float], v2: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    if not v1 or not v2:
+        return 0.0
+    dot = sum(a * b for a, b in zip(v1, v2))
+    norm1 = sum(a * a for a in v1) ** 0.5
+    norm2 = sum(a * a for a in v2) ** 0.5
+    if norm1 == 0 or norm2 == 0:
+        return 0.0
+    return dot / (norm1 * norm2)
+
+
+def load_folder_data(root: str) -> tuple[Dict[str, list], Dict[str, str]]:
+    """Load folder vectors and contexts from the organizer output."""
+    vectors_path = os.path.join(root, "folder_vectors.json")
+    contexts_path = os.path.join(root, "folder_contexts.json")
+    with open(vectors_path, "r", encoding="utf-8") as f:
+        vectors: Dict[str, list] = json.load(f)
+    with open(contexts_path, "r", encoding="utf-8") as f:
+        contexts: Dict[str, str] = json.load(f)
+    return vectors, contexts
+
+
+def suggest_folder_for_file(
+    filepath: str,
+    folder_vectors: Dict[str, list],
+) -> str:
+    """Return the folder with the highest embedding similarity."""
+    text = extract_text_file(filepath, n_chars=2000)
+    embedding = get_embedding(text)
+    best_folder = list(folder_vectors.keys())[0]
+    best_score = float("-inf")
+    for folder, vec in folder_vectors.items():
+        score = cosine_similarity(embedding, vec)
+        if score > best_score:
+            best_score = score
+            best_folder = folder
+    return best_folder
+
+
+def map_files(source: str, folder_vectors: Dict[str, list]) -> Dict[str, str]:
+    """Map each file in ``source`` recursively to a destination folder."""
+    mapping: Dict[str, str] = {}
+    for root, _, files in os.walk(source):
+        for name in files:
+            path = os.path.join(root, name)
+            dest = suggest_folder_for_file(path, folder_vectors)
+            mapping[path] = dest
+    return mapping
+
+
+def apply_mapping(mapping: Dict[str, str]) -> None:
+    """Move files according to ``mapping``."""
+    for src, dst_folder in mapping.items():
+        os.makedirs(dst_folder, exist_ok=True)
+        shutil.move(src, os.path.join(dst_folder, os.path.basename(src)))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Map files to organized folders")
+    parser.add_argument("--input", required=True, help="Folder with files to map")
+    parser.add_argument(
+        "--root",
+        required=True,
+        help="Root folder that contains folder_vectors.json and folder_contexts.json",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Move files based on generated mapping"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    folder_vectors, folder_contexts = load_folder_data(args.root)
+    mapping = map_files(args.input, folder_vectors)
+    mapping_file = os.path.join(args.input, "file_mappings.json")
+    with open(mapping_file, "w", encoding="utf-8") as f:
+        json.dump(mapping, f, indent=2, ensure_ascii=False)
+    if args.apply:
+        apply_mapping(mapping)
+    print(f"Saved mapping to {mapping_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/file_organizer/organizer.py
+++ b/file_organizer/organizer.py
@@ -16,6 +16,7 @@ from langchain_huggingface import HuggingFaceEmbeddings
 # Preload the embedding model once for efficiency using LangChain
 _EMBED_MODEL = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
 
+
 def get_embedding(text: str) -> list[float]:
     """Return an embedding vector for the given text."""
     return _EMBED_MODEL.embed_query(text)
@@ -27,14 +28,21 @@ from .llm_provider import get_llm
 # Configuration can be supplied via command line or environment variables.
 # Environment variable fallbacks: FO_ROOT_DIR, FO_N_SAMPLE_FILES, FO_OLLAMA_MODEL
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Summarize folders using a local LLM")
-    parser.add_argument("--root", required=False,
-                        default=os.environ.get("FO_ROOT_DIR"),
-                        help="Root directory to analyze")
-    parser.add_argument("--samples", type=int,
-                        default=int(os.environ.get("FO_N_SAMPLE_FILES", 10)),
-                        help="Number of sample files per folder")
+    parser.add_argument(
+        "--root",
+        required=False,
+        default=os.environ.get("FO_ROOT_DIR"),
+        help="Root directory to analyze",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=int(os.environ.get("FO_N_SAMPLE_FILES", 10)),
+        help="Number of sample files per folder",
+    )
     parser.add_argument(
         "--model",
         default=os.environ.get("FO_OLLAMA_MODEL", "llama3"),
@@ -58,13 +66,17 @@ def parse_args():
         default=os.environ.get("FIREWORKS_API_KEY"),
         help="API key for Fireworks provider",
     )
-    parser.add_argument("--resume", action="store_true",
-                        help="Resume from existing folder_contexts.json")
-    parser.add_argument("--verbose", action="store_true",
-                        help="Enable verbose output")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from existing folder_contexts.json",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
     return parser.parse_args()
 
+
 # --- File Extractors ---
+
 
 def extract_text_txt(path, n_chars: Optional[int] = None):
     try:
@@ -74,6 +86,7 @@ def extract_text_txt(path, n_chars: Optional[int] = None):
     except Exception:
         return ""
 
+
 def extract_text_docx(path, n_chars: Optional[int] = None):
     try:
         doc = Document(path)
@@ -81,6 +94,7 @@ def extract_text_docx(path, n_chars: Optional[int] = None):
         return text if n_chars is None else text[:n_chars]
     except Exception:
         return ""
+
 
 def extract_text_pdf(path, n_chars: Optional[int] = None):
     try:
@@ -92,17 +106,21 @@ def extract_text_pdf(path, n_chars: Optional[int] = None):
     except Exception:
         return ""
 
+
 def extract_text_xlsx(path, n_chars: Optional[int] = None):
     try:
         wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
         text = ""
         for ws in wb.worksheets:
             for row in ws.iter_rows(values_only=True):
-                rowtext = "\t".join([str(cell) if cell is not None else "" for cell in row])
+                rowtext = "\t".join(
+                    [str(cell) if cell is not None else "" for cell in row]
+                )
                 text += rowtext + "\n"
         return text if n_chars is None else text[:n_chars]
     except Exception:
         return ""
+
 
 def extract_text_pptx(path, n_chars: Optional[int] = None):
     try:
@@ -115,6 +133,7 @@ def extract_text_pptx(path, n_chars: Optional[int] = None):
         return text if n_chars is None else text[:n_chars]
     except Exception:
         return ""
+
 
 # Mapping of file extensions to their extraction functions
 EXTRACTORS = {
@@ -129,20 +148,20 @@ EXTRACTORS = {
     ".ppt": extract_text_pptx,
 }
 
+
 def extract_text_file(path, n_chars: Optional[int] = None):
     ext = os.path.splitext(path)[1].lower()
     extractor = EXTRACTORS.get(ext)
     return extractor(path, n_chars) if extractor else ""
 
+
 def get_sample_files(folder, n):
-    files = [f for f in os.listdir(folder)
-             if os.path.isfile(os.path.join(folder, f))]
+    files = [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
     if not files:
         return []
 
     # Prefer recently modified files and distribute across extensions
-    files.sort(key=lambda f: os.path.getmtime(os.path.join(folder, f)),
-               reverse=True)
+    files.sort(key=lambda f: os.path.getmtime(os.path.join(folder, f)), reverse=True)
     by_ext = defaultdict(list)
     for f in files:
         by_ext[os.path.splitext(f)[1]].append(f)
@@ -178,7 +197,9 @@ def get_file_summary(filepath, llm):
     summary = call_llm(prompt, llm=llm)
     return summary.strip()
 
+
 # -- Main hierarchical logic --
+
 
 def build_folder_tree(root_dir):
     """Map each folder to its children."""
@@ -190,6 +211,7 @@ def build_folder_tree(root_dir):
             child = os.path.join(folder, d)
             tree[folder].append(child)
     return tree, all_folders
+
 
 def get_folders_in_bottom_up_order(tree, root_dir):
     """Return a list of folders, leaves first, root last."""
@@ -261,7 +283,9 @@ class FolderOrganizer:
         self.order = get_folders_in_bottom_up_order(self.tree, self.root)
         return self.tree
 
-    def write_results(self, folder_contexts: Dict[str, str], folder_vectors: Dict[str, list]) -> None:
+    def write_results(
+        self, folder_contexts: Dict[str, str], folder_vectors: Dict[str, list]
+    ) -> None:
         with open(self.out_json, "w", encoding="utf-8") as f:
             json.dump(folder_contexts, f, ensure_ascii=False, indent=2)
         with open(self.out_vectors, "w", encoding="utf-8") as f:
@@ -373,5 +397,7 @@ def main():
 
     organizer.build_tree()
     organizer.summarize_folders(resume=args.resume)
+
+
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,4 @@ dependencies = [
 
 [project.scripts]
 file-organizer = "file_organizer.organizer:main"
+file-mapper = "file_organizer.mapper:main"

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,0 +1,31 @@
+import importlib
+import types
+from unittest.mock import MagicMock
+
+# Patch embeddings to avoid network
+mock_embeddings = types.ModuleType("langchain_huggingface")
+mock_embed_instance = MagicMock()
+mock_embed_instance.embed_query.return_value = [1.0]
+mock_embeddings.HuggingFaceEmbeddings = MagicMock(return_value=mock_embed_instance)
+
+import sys
+
+sys.modules["langchain_huggingface"] = mock_embeddings
+sys.modules["langchain_huggingface.embeddings"] = mock_embeddings
+
+mapper = importlib.import_module("file_organizer.mapper")
+mapper.get_embedding = MagicMock(return_value=[1.0])
+mapper.extract_text_file = MagicMock(return_value="test")
+
+
+def test_cosine_similarity():
+    assert mapper.cosine_similarity([1, 0], [1, 0]) == 1
+    assert mapper.cosine_similarity([1, 0], [0, 1]) == 0
+
+
+def test_suggest_folder_for_file(tmp_path):
+    file = tmp_path / "f.txt"
+    file.write_text("data")
+    vectors = {str(tmp_path / "a"): [1.0], str(tmp_path / "b"): [0.0]}
+    dest = mapper.suggest_folder_for_file(str(file), vectors)
+    assert dest == str(tmp_path / "a")

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -10,11 +10,11 @@ mock_embed_instance = MagicMock()
 mock_embed_instance.embed_query.return_value = [0.0]
 mock_embeddings.HuggingFaceEmbeddings = MagicMock(return_value=mock_embed_instance)
 
+sys.modules["langchain_huggingface"] = mock_embeddings
+sys.modules["langchain_huggingface.embeddings"] = mock_embeddings
 
-sys.modules['langchain_huggingface.embeddings'] = mock_embeddings
 
-
-organizer = importlib.import_module('file_organizer.organizer')
+organizer = importlib.import_module("file_organizer.organizer")
 organizer.get_llm = MagicMock(return_value=MagicMock())
 
 


### PR DESCRIPTION
## Summary
- introduce `file_mappings.json` output via new `file-mapper` command
- document file mapping usage in README
- provide helper for cosine similarity and mapping logic
- include tests for new mapper module
- register entry point for `file-mapper`

## Testing
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f25b2de88322a7318ee1da9f419a