### PR TITLE
Improve file mapper with LLM-based matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ To map files from another folder to the most relevant destination within an exis
 python -m file_organizer.mapper --input /path/to/new/files --root /path/to/root
 ```
 
-The command creates a `file_mappings.json` file inside the input folder listing the suggested destination for each file. Use `--apply` to automatically move the files based on that mapping.
+The command creates a `file_mappings.json` file inside the input folder listing
+the suggested destination for each file. The mapper first selects the top few
+candidate folders using vector similarity and then asks the LLM to choose the
+best match based on the stored folder summaries. Use `--apply` to automatically
+move the files based on that mapping. Adjust the number of candidates with
+`--top-n` and specify the model and provider just like when generating the
+folder summaries.
 
 ## How it works
 

--- a/file_organizer/mapper.py
+++ b/file_organizer/mapper.py
@@ -2,9 +2,53 @@ import os
 import json
 import argparse
 import shutil
-from typing import Dict
+import logging
+from typing import Dict, List
 
 from .organizer import get_embedding, extract_text_file
+from .llm_provider import get_llm
+
+
+def call_llm(prompt: str, llm, retries: int = 1) -> str:
+    """Invoke ``llm`` with ``prompt`` handling transient errors."""
+    for attempt in range(retries + 1):
+        try:
+            return llm.invoke(prompt).content.strip()
+        except Exception as e:  # pragma: no cover - network errors
+            if attempt >= retries:
+                logging.error("[llm error] %s", e)
+                return ""
+            logging.warning("LLM call failed, retrying...")
+
+
+def choose_best_folder_via_llm(
+    file_text: str,
+    candidate_folders: List[str],
+    folder_contexts: Dict[str, str],
+    llm,
+) -> str:
+    """Return the folder that best matches the file using the LLM."""
+
+    folder_descriptions = []
+    for i, folder in enumerate(candidate_folders, 1):
+        desc = folder_contexts.get(folder, "")
+        folder_descriptions.append(f"{i}. {folder}: {desc}")
+
+    prompt = (
+        "You are helping to organize files into folders. "
+        "Choose the number of the folder that best matches the given file "
+        "content.\n\nFile content:\n"
+        f"{file_text}\n\nFolders:\n" + "\n".join(folder_descriptions) +
+        "\n\nRespond with just the number of the best folder."
+    )
+
+    response = call_llm(prompt, llm)
+    for token in response.split():
+        if token.isdigit():
+            idx = int(token)
+            if 1 <= idx <= len(candidate_folders):
+                return candidate_folders[idx - 1]
+    return candidate_folders[0]
 
 
 def cosine_similarity(v1: list[float], v2: list[float]) -> float:
@@ -33,27 +77,42 @@ def load_folder_data(root: str) -> tuple[Dict[str, list], Dict[str, str]]:
 def suggest_folder_for_file(
     filepath: str,
     folder_vectors: Dict[str, list],
+    folder_contexts: Dict[str, str],
+    llm,
+    *,
+    top_n: int = 3,
 ) -> str:
-    """Return the folder with the highest embedding similarity."""
+    """Return the folder that best fits the file content."""
+
     text = extract_text_file(filepath, n_chars=2000)
     embedding = get_embedding(text)
-    best_folder = list(folder_vectors.keys())[0]
-    best_score = float("-inf")
-    for folder, vec in folder_vectors.items():
-        score = cosine_similarity(embedding, vec)
-        if score > best_score:
-            best_score = score
-            best_folder = folder
-    return best_folder
+
+    scored = [
+        (folder, cosine_similarity(embedding, vec))
+        for folder, vec in folder_vectors.items()
+    ]
+    scored.sort(key=lambda x: x[1], reverse=True)
+    candidates = [f for f, _ in scored[:top_n]]
+    return choose_best_folder_via_llm(text, candidates, folder_contexts, llm)
 
 
-def map_files(source: str, folder_vectors: Dict[str, list]) -> Dict[str, str]:
+def map_files(
+    source: str,
+    folder_vectors: Dict[str, list],
+    folder_contexts: Dict[str, str],
+    llm,
+    *,
+    top_n: int = 3,
+) -> Dict[str, str]:
     """Map each file in ``source`` recursively to a destination folder."""
+
     mapping: Dict[str, str] = {}
     for root, _, files in os.walk(source):
         for name in files:
             path = os.path.join(root, name)
-            dest = suggest_folder_for_file(path, folder_vectors)
+            dest = suggest_folder_for_file(
+                path, folder_vectors, folder_contexts, llm, top_n=top_n
+            )
             mapping[path] = dest
     return mapping
 
@@ -76,13 +135,49 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--apply", action="store_true", help="Move files based on generated mapping"
     )
+    parser.add_argument("--top-n", type=int, default=3, help="Number of top vector matches to consider")
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("FO_OLLAMA_MODEL", "llama3"),
+        help="Model name for the selected provider",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["ollama", "openai", "fireworks"],
+        default=os.environ.get("FO_PROVIDER", "ollama"),
+        help="LLM provider to use",
+    )
+    parser.add_argument(
+        "--openai-api-key",
+        dest="openai_api_key",
+        default=os.environ.get("OPENAI_API_KEY"),
+        help="API key for OpenAI provider",
+    )
+    parser.add_argument(
+        "--fireworks-api-key",
+        dest="fireworks_api_key",
+        default=os.environ.get("FIREWORKS_API_KEY"),
+        help="API key for Fireworks provider",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
     folder_vectors, folder_contexts = load_folder_data(args.root)
-    mapping = map_files(args.input, folder_vectors)
+    llm = get_llm(
+        args.model,
+        args.provider,
+        openai_api_key=args.openai_api_key,
+        fireworks_api_key=args.fireworks_api_key,
+    )
+    mapping = map_files(
+        args.input,
+        folder_vectors,
+        folder_contexts,
+        llm,
+        top_n=args.top_n,
+    )
     mapping_file = os.path.join(args.input, "file_mappings.json")
     with open(mapping_file, "w", encoding="utf-8") as f:
         json.dump(mapping, f, indent=2, ensure_ascii=False)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -27,5 +27,10 @@ def test_suggest_folder_for_file(tmp_path):
     file = tmp_path / "f.txt"
     file.write_text("data")
     vectors = {str(tmp_path / "a"): [1.0], str(tmp_path / "b"): [0.0]}
-    dest = mapper.suggest_folder_for_file(str(file), vectors)
+    contexts = {str(tmp_path / "a"): "A", str(tmp_path / "b"): "B"}
+    llm = MagicMock()
+    llm.invoke.return_value = MagicMock(content="1")
+    dest = mapper.suggest_folder_for_file(
+        str(file), vectors, contexts, llm, top_n=2
+    )
     assert dest == str(tmp_path / "a")


### PR DESCRIPTION
## Summary
- integrate `get_llm` into the mapper
- rank top folders by embedding similarity
- use the LLM to choose the best folder from candidates
- expose provider/model options and `--top-n` on the mapper CLI
- update tests and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f983112083228f1ab481b881655a