### PR TITLE
Reuse existing mappings in file-mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ move the files based on that mapping. Adjust the number of candidates with
 `--top-n` and specify the model and provider just like when generating the
 folder summaries. If none of the vector matches exceed a chosen similarity
 threshold, the file will remain unmapped. Control this with `--min-sim`.
+If a `file_mappings.json` already exists, it is loaded and reused so that
+previous suggestions are preserved and only new files are analyzed.
 
 ### Reorganization planning
 

--- a/file_organizer/mapper.py
+++ b/file_organizer/mapper.py
@@ -115,13 +115,16 @@ def map_files(
     *,
     top_n: int = 3,
     min_similarity: float = 0.0,
+    existing_mapping: Dict[str, str] | None = None,
 ) -> Dict[str, str]:
     """Map each file in ``source`` recursively to a destination folder."""
 
-    mapping: Dict[str, str] = {}
+    mapping: Dict[str, str] = dict(existing_mapping or {})
     for root, _, files in os.walk(source):
         for name in files:
             path = os.path.join(root, name)
+            if path in mapping:
+                continue
             dest = suggest_folder_for_file(
                 path,
                 folder_vectors,
@@ -198,6 +201,11 @@ def main() -> None:
         openai_api_key=args.openai_api_key,
         fireworks_api_key=args.fireworks_api_key,
     )
+    mapping_file = os.path.join(args.input, "file_mappings.json")
+    existing_mapping: Dict[str, str] = {}
+    if os.path.exists(mapping_file):
+        with open(mapping_file, "r", encoding="utf-8") as f:
+            existing_mapping = json.load(f)
     mapping = map_files(
         args.input,
         folder_vectors,
@@ -205,8 +213,8 @@ def main() -> None:
         llm,
         top_n=args.top_n,
         min_similarity=args.min_sim,
+        existing_mapping=existing_mapping,
     )
-    mapping_file = os.path.join(args.input, "file_mappings.json")
     with open(mapping_file, "w", encoding="utf-8") as f:
         json.dump(mapping, f, indent=2, ensure_ascii=False)
     if args.apply:

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -47,3 +47,28 @@ def test_suggest_folder_for_file_min_similarity(tmp_path):
         str(file), vectors, contexts, llm, top_n=1, min_similarity=0.5
     )
     assert dest == ""
+
+
+def test_map_files_uses_existing_mapping(tmp_path):
+    f1 = tmp_path / "a.txt"
+    f1.write_text("data")
+    f2 = tmp_path / "b.txt"
+    f2.write_text("data")
+
+    existing = {str(f1): "/dest"}
+    mapper.suggest_folder_for_file = MagicMock(return_value="/new")
+    llm = MagicMock()
+
+    mapping = mapper.map_files(
+        str(tmp_path),
+        {},
+        {},
+        llm,
+        existing_mapping=existing,
+    )
+
+    assert mapping[str(f1)] == "/dest"
+    assert mapping[str(f2)] == "/new"
+    mapper.suggest_folder_for_file.assert_called_once_with(
+        str(f2), {}, {}, llm, top_n=3, min_similarity=0.0
+    )


### PR DESCRIPTION
## Summary
- support `file_mappings.json` reuse in mapper
- document reuse of mapping file in README
- test that existing mappings are loaded

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840af0c8808322be073174182be016